### PR TITLE
Update report path to match what router expects

### DIFF
--- a/app/main/views/service_updates.py
+++ b/app/main/views/service_updates.py
@@ -57,6 +57,6 @@ def download_approved_service_edits(date):
         current_app.config['DM_REPORTS_BUCKET'], endpoint_url=current_app.config.get("DM_S3_ENDPOINT_URL")
     )
 
-    path = f"reports/approved-service-edits-{date}.csv"
+    path = f"common/reports/approved-service-edits-{date}.csv"
     url = get_signed_url(reports_bucket, path, current_app.config['DM_ASSETS_URL']) or abort(404)
     return redirect(url)

--- a/tests/app/main/views/test_service_updates.py
+++ b/tests/app/main/views/test_service_updates.py
@@ -213,7 +213,7 @@ class TestServiceUpdates(LoggedInApplicationTest):
         assert get_signed_url.call_args_list == [
             mock.call(
                 s3.S3.return_value,
-                "reports/approved-service-edits-2022-06.csv",
+                "common/reports/approved-service-edits-2022-06.csv",
                 'http://example.com'
             ),
         ]


### PR DESCRIPTION
https://trello.com/c/F0h3RRkV/2494-send-ccs-list-of-approved-service-edits-for-month-past

This endpoint is not currently working in preview. I think that may be because the current report path doesn't match the regex in router (`^/[^/]+/reports/.*` - https://github.com/Crown-Commercial-Service/digitalmarketplace-router/blob/main/templates/assets.j2). Try adding 'common' to the path (where other reports have a framework slug) to see if that fixes things.

Follow-on from https://github.com/Crown-Commercial-Service/digitalmarketplace-admin-frontend/pull/867