### PR TITLE
Show errors when editing declaration

### DIFF
--- a/app/templates/suppliers/edit_declaration.html
+++ b/app/templates/suppliers/edit_declaration.html
@@ -33,7 +33,11 @@
       <div class="govuk-grid-column-two-thirds">
        <input id="csrf_token" name="csrf_token" type="hidden" value="{{ csrf_token() }}">
         {% for question in section.questions %}
-          {{ forms[question.type](question, declaration, {}) }}
+          {% if errors and errors[question.id] or question.type == 'multiquestion' %}
+            {{ forms[question.type](question, declaration, errors) }}
+          {% else %}
+            {{ forms[question.type](question, declaration, {}) }}
+          {% endif %}
         {% endfor %}
 
         {{ govukButton({

--- a/tests/app/main/views/test_suppliers.py
+++ b/tests/app/main/views/test_suppliers.py
@@ -2215,6 +2215,16 @@ class TestEditingASupplierDeclaration(LoggedInApplicationTest):
         self.data_api_client.set_supplier_declaration.assert_called_once_with(
             1234, 'g-cloud-7', declaration, 'test@example.com')
 
+    def test_should_fail_if_validation_error(self):
+        self.data_api_client.set_supplier_declaration.side_effect = HTTPError(None, {'PR1': 'required'})
+
+        response = self.client.post(
+            '/admin/suppliers/1234/edit/declarations/g-cloud-7/g-cloud-7-essentials',
+            data={'PR1': None})
+
+        assert response.status_code == 400
+        assert 'There was a problem with the answer to this question' in response.get_data(as_text=True)
+
 
 @mock.patch('app.main.views.suppliers.download_agreement_file')
 class TestDownloadSignedAgreementFile(LoggedInApplicationTest):


### PR DESCRIPTION
Sourcing admins are able to edit supplier declarations. The page has no error handling, so any errors will result in an unhelpful 500 page. Update the error handling to match that for editing services. Now, if a sourcing admin makes an invalid edit, they will get a message explaining why their change is invalid.

No associated ticket - I just noticed this while looking at how modern slavery statements are handled. I'll port this to 1.5 once merged.

Screenshots of the banner and inline text:

![Screenshot 2022-06-08 at 17 12 47](https://user-images.githubusercontent.com/15256121/172666064-e9ae44e6-8d89-4fe0-a6f6-84d351116a27.png)

![Screenshot 2022-06-08 at 17 12 52](https://user-images.githubusercontent.com/15256121/172666057-3f3ec5d9-080e-48aa-96ee-22d3b3aadc78.png)
