### PR TITLE
Support uploading declaration documents

### DIFF
--- a/tests/app/fixtures/frameworks.json
+++ b/tests/app/fixtures/frameworks.json
@@ -478,6 +478,50 @@
       "slug": "g-cloud-11",
       "status": "open",
       "variations": {}
+    },
+    {
+      "allow_declaration_reuse": false,
+      "application_close_date": null,
+      "clarificationQuestionsOpen": true,
+      "countersignerName": null,
+      "framework": "g-cloud",
+      "family": "g-cloud",
+      "frameworkAgreementDetails": {},
+      "frameworkAgreementVersion": null,
+      "id": 12,
+      "lots": [
+        {
+          "allowsBrief": false,
+          "id": 9,
+          "name": "Cloud hosting",
+          "oneServiceLimit": false,
+          "slug": "cloud-hosting",
+          "unitPlural": "services",
+          "unitSingular": "service"
+        },
+        {
+          "allowsBrief": false,
+          "id": 10,
+          "name": "Cloud software",
+          "oneServiceLimit": false,
+          "slug": "cloud-software",
+          "unitPlural": "services",
+          "unitSingular": "service"
+        },
+        {
+          "allowsBrief": false,
+          "id": 11,
+          "name": "Cloud support",
+          "oneServiceLimit": false,
+          "slug": "cloud-support",
+          "unitPlural": "services",
+          "unitSingular": "service"
+        }
+      ],
+      "name": "G-Cloud 12",
+      "slug": "g-cloud-12",
+      "status": "open",
+      "variations": {}
     }
   ]
 }

--- a/tests/app/main/views/test_suppliers.py
+++ b/tests/app/main/views/test_suppliers.py
@@ -2225,6 +2225,18 @@ class TestEditingASupplierDeclaration(LoggedInApplicationTest):
         assert response.status_code == 400
         assert 'There was a problem with the answer to this question' in response.get_data(as_text=True)
 
+    def test_should_upload_file(self):
+        response = self.client.post(
+            '/admin/suppliers/1234/edit/declarations/g-cloud-12/modern-slavery',
+            data={'modernSlaveryStatement': (BytesIO(valid_pdf_bytes), 'test.pdf')},
+        )
+
+        assert response.status_code == 302
+        self.data_api_client.set_supplier_declaration.assert_called_once()
+        assert self.data_api_client.set_supplier_declaration.call_args.args[2]['modernSlaveryStatement'] == \
+            'https://assets.test.digitalmarketplace.service.gov.uk/g-cloud-12/documents/1234/' \
+            'modern-slavery-statement-2015-01-01-1200.pdf'
+
 
 @mock.patch('app.main.views.suppliers.download_agreement_file')
 class TestDownloadSignedAgreementFile(LoggedInApplicationTest):


### PR DESCRIPTION
Sourcing admins can already edit declarations. Allow them to upload declaration documents as well. Substantially copied from the same logic that already exists for service questions.

There is no need for this. However, it should make it easier to allow (non-sourcing) admins to edit modern slavery statements in future.

Builds on top of https://github.com/Crown-Commercial-Service/digitalmarketplace-admin-frontend/pull/871