### PR TITLE
Allow admins to view contacts for expired G-Cloud frameworks

### DIFF
--- a/app/main/views/users.py
+++ b/app/main/views/users.py
@@ -67,9 +67,7 @@ def change_user_name(user_id):
 @role_required('admin-framework-manager', 'admin-ccs-category', 'admin-ccs-data-controller')
 def user_list_page_for_framework(framework_slug):
     framework = data_api_client.get_framework(framework_slug).get("frameworks")
-    if framework is None or framework['status'] == 'coming' or (
-        framework['status'] == 'expired' and framework['family'] != 'digital-outcomes-and-specialists'
-    ):
+    if framework is None or framework['status'] == 'coming':
         abort(404)
 
     supplier_csv_url = url_for(

--- a/tests/app/main/views/test_users.py
+++ b/tests/app/main/views/test_users.py
@@ -275,32 +275,6 @@ class TestUserListPage(LoggedInApplicationTest):
             '//h1//text()')[0].strip()
         assert page_heading == "Download supplier lists for G-Cloud 9"
 
-    @pytest.mark.parametrize('family,should_be_shown', (
-        ('g-cloud', False),
-        ('digital-outcomes-and-specialists', True),
-    ))
-    def test_dos_frameworks_only_expired_frameworks_available(self, s3, family, should_be_shown):
-        self.data_api_client.get_framework.return_value = FrameworkStub(
-            family=family,
-            status='expired',
-            slug=f'sunt-me-gratis-12',
-            name=f'Sunt Me Gratis 12',
-        ).single_result_response()
-
-        response = self.client.get(f"/admin/frameworks/sunt-me-gratis-12/users")
-
-        assert self.data_api_client.mock_calls == [
-            mock.call.get_framework("sunt-me-gratis-12")
-        ]
-
-        if should_be_shown:
-            assert response.status_code == 200
-            document = html.fromstring(response.get_data(as_text=True))
-            page_heading = document.xpath('normalize-space(string(//h1))')
-            assert page_heading == f"Download supplier lists for Sunt Me Gratis 12"
-        else:
-            assert response.status_code == 404
-
     @mock.patch('app.main.views.users.get_signed_url')
     def test_download_supplier_user_account_list_report_redirects_to_s3_url(self, get_signed_url, s3):
         get_signed_url.return_value = 'http://path/to/csv?querystring'


### PR DESCRIPTION
Now that we're allowing them to view expired G-Cloud frameworks in the first place (#736).

Should fix https://ci.marketplace.team/job/apps-are-working-production/31854/smoulder_20test_20report/