### PR TITLE
Update Dockerfile.wsgi to copy template files

### DIFF
--- a/docker-aws/Dockerfile.wsgi
+++ b/docker-aws/Dockerfile.wsgi
@@ -7,4 +7,5 @@ FROM 473251818902.dkr.ecr.eu-west-2.amazonaws.com/dmp-base-wsgi:latest
 COPY --from=buildstatic ${APP_DIR}/node_modules/digitalmarketplace-govuk-frontend ${APP_DIR}/node_modules/digitalmarketplace-govuk-frontend
 COPY --from=buildstatic ${APP_DIR}/node_modules/govuk-frontend ${APP_DIR}/node_modules/govuk-frontend
 COPY --from=buildstatic ${APP_DIR}/app/content ${APP_DIR}/app/content
+COPY --from=buildstatic ${APP_DIR}/app/templates/toolkit ${APP_DIR}/app/templates/toolkit
 COPY --from=buildstatic ${APP_DIR}/app/static ${APP_DIR}/app/static


### PR DESCRIPTION
Admin (and supplier) frontend uses an older version of some GOV.UK packages and as such it requires some files to be copied into the build.